### PR TITLE
fix a flaky test, caused by xml string comparison

### DIFF
--- a/karate-core/src/test/java/com/intuit/karate/report/ReportUtilsTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/report/ReportUtilsTest.java
@@ -67,12 +67,15 @@ class ReportUtilsTest {
 
     @Test
     void testCustomTags() {
-        String expectedCustomTags = "<properties><property name=\"requirement\" value=\"CALC-2\"/><property name=\"test_key\" value=\"CALC-2\"/></properties>";
+        String expectedCustomTagsOption1 = "<properties><property name=\"requirement\" value=\"CALC-2\"/><property name=\"test_key\" value=\"CALC-2\"/></properties>";
+        String expectedCustomTagsOption2 = "<properties><property name=\"test_key\" value=\"CALC-2\"/><property name=\"requirement\" value=\"CALC-2\"/></properties>";
+
         Feature feature = Feature.read("classpath:com/intuit/karate/report/customTags.feature");
         FeatureRuntime fr = FeatureRuntime.of(new Suite(), new FeatureCall(feature));
         fr.run();
         File file = ReportUtils.saveJunitXml("target", fr.result, null);
-        assertTrue(FileUtils.toString(file).contains(expectedCustomTags));
+        String xmlString = FileUtils.toString(file);
+        assertTrue(xmlString.contains(expectedCustomTagsOption1) || xmlString.contains(expectedCustomTagsOption2));
     }
 
 }


### PR DESCRIPTION
### Description
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [x] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation


Fixed a flaky test, which implicitly relies on the serialization order when generating an XML string.

### Root Cause
The original test tried to compare a hard-coded XML string with another dynamically generated XML string, but the generated XML string has indeterminate order of properties, the test is thus flaky. 

### Fix
Given that in this particular test, the properties have only two possible orders, we can simply list out all permutations, and compare them with the generated XML string.


### Key changed/added classes in this PR
 * `ReportUtilsTest`