### PR TITLE
Fix a flaky test, by fixing a nondeterministic behavior.

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/core/Tags.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/Tags.java
@@ -31,8 +31,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -107,7 +107,7 @@ public class Tags implements Iterable<Tag> {
     }
 
     public static Tags merge(List<Tag>... lists) {
-        Set<Tag> tags = new HashSet();
+        Set<Tag> tags = new LinkedHashSet();
         for (List<Tag> list : lists) {
             if (list != null) {
                 tags.addAll(list);


### PR DESCRIPTION
### Description

- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [X] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

Fix a flaky test, caused by a nondeterministic behavior when generating feature results.

### Related Test
com.intuit.karate.core.FeatureResultTest.testJsonConversion

### Root Cause
https://github.com/lxb007981/karate/blob/7211131d20bdf1ec44bc7730ceb0d459c5c843d4/karate-core/src/test/java/com/intuit/karate/core/FeatureResultTest.java#L32-L36
In this match statement, the test dynamically generates a feature result, and compares it with a hard-coded string.

https://github.com/lxb007981/karate/blob/7211131d20bdf1ec44bc7730ceb0d459c5c843d4/karate-core/src/main/java/com/intuit/karate/core/Tags.java#L109-L132

However, when generating a feature result, a simple `HashSet` is used and converted to an `ArrayList`. Note that `HashSet` does not gurantee the order of iteration, the generated list is thus nondeterministic. This nondeterministic list is later compared to a hard-coded string, which leads to a flaky test.

### Fix
Since this behavior is not expected, we directly modify the source code, and replace `HashSet` with `LinkedHashSet`, which gurantees a deterministic order of iteration. The test is written correctly and we did not change the test code, but the dependent source code behaves unexpectedly.

#### About performance
`LinkedHashSet` is slightly slower than `HashSet`, but it brings the correct semantics.

### How to reproduce the test
**Java version**: 11.0.20.1
**Maven version**: 3.6.3

1. Build the module
`mvn clean install -DskipTests -pl karate-core -am`
2. Test without shuffling
`mvn -pl karate-core test -Dtest=com.intuit.karate.core.FeatureResultTest#testJsonConversion`
This test passed.

3. Test with shuffling using [NonDex](https://github.com/TestingResearchIllinois/NonDex)
`mvn -pl karate-core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.intuit.karate.core.FeatureResultTest#testJsonConversion`
This test passed with the proposed fix but failed without it.