### PR TITLE
Fix a flaky test, caused by a nondeterministic behavior.

### DIFF
--- a/karate-core/src/test/java/com/intuit/karate/core/parser/FeatureParserTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/core/parser/FeatureParserTest.java
@@ -52,7 +52,12 @@ class FeatureParserTest {
         match(map.get("tags"), "[{ name: '@foo', line: 1 }]");
         ScenarioResult sr = result.getScenarioResults().get(0);
         map = sr.toCucumberJson();
-        match(map.get("tags"), "[{ name: '@bar', line: 5 }, { name: '@foo', line: 1 }]");
+        Object actual = map.get("tags");
+        String expected1 = "[{ name: '@foo', line: 1 }, { name: '@bar', line: 5 }]";
+        String expected2 = "[{ name: '@bar', line: 5 }, { name: '@foo', line: 1 }]";
+        if(!(Match.evaluate(actual).isEqualTo(expected1).pass)){
+            match(actual, expected2);
+        }
         ReportUtils.saveCucumberJson("target", result, null);
         ReportUtils.saveJunitXml("target", result, null);
     }


### PR DESCRIPTION
### Description

- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [X] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

Fix a flaky test, caused by a nondeterministic iteration order when generating feature results.

### Related Test
com.intuit.karate.core.parser.FeatureParserTest.testEngineForSimpleFeature
https://github.com/lxb007981/karate/blob/7211131d20bdf1ec44bc7730ceb0d459c5c843d4/karate-core/src/test/java/com/intuit/karate/core/parser/FeatureParserTest.java#L55
This test is found flaky with [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.

### Root Cause
https://github.com/lxb007981/karate/blob/7211131d20bdf1ec44bc7730ceb0d459c5c843d4/karate-core/src/main/java/com/intuit/karate/core/Tags.java#L109-L110

https://github.com/lxb007981/karate/blob/7211131d20bdf1ec44bc7730ceb0d459c5c843d4/karate-core/src/main/java/com/intuit/karate/core/ScenarioResult.java#L230-L233

When generating a feature result, simple `HashSet` and `HashMap` were used. However, later in the code these collections were iterated, converted to a list, and used for comparison. Due to the nondeterministic order of iteration of `HashSet`/`HashMap`, the generated list is also nondeterministic. in the test `com.intuit.karate.core.parser.FeatureParserTest.testEngineForSimpleFeature`, the nondeterministic list is compared to a hard-coded string, which leads to a flaky test.

### Fix
Since this generated list has indeterminate order of two items inside, we can list all two permutations and let the test to match any one of them.

### How to reproduce the test
**Java version**: 11.0.20.1
**Maven version**: 3.6.3

1. Build the module
`mvn clean install -DskipTests -pl karate-core -am`

2. Test without shuffling
`mvn -pl karate-core test -Dtest=com.intuit.karate.core.parser.FeatureParserTest#testEngineForSimpleFeature`
This test passed.

3. Test with shuffling using [NonDex](https://github.com/TestingResearchIllinois/NonDex)
`mvn -pl karate-core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.intuit.karate.core.parser.FeatureParserTest#testEngineForSimpleFeature`
This test passed with the proposed fix but failed without it.